### PR TITLE
Occurence "OpenOffice.org" in dialog Writing Aids for new thesaurus

### DIFF
--- a/main/lingucomponent/source/thesaurus/libnth/nthesimp.cxx
+++ b/main/lingucomponent/source/thesaurus/libnth/nthesimp.cxx
@@ -575,7 +575,7 @@ OUString SAL_CALL Thesaurus::getServiceDisplayName( const Locale& /*rLocale*/ )
 		throw(RuntimeException)
 {
 	MutexGuard	aGuard( GetLinguMutex() );
-	return A2OU( "OpenOffice.org New Thesaurus" );
+	return A2OU( "New Thesaurus" );
 }
 
 


### PR DESCRIPTION
Just noticed the occurrence of the string "OpenOffice.org New Thesaurus" in the
dialog Writing Aids (Tools > Options > Language Settings > Writing Aids) in the
Developer Build 4.2.0

This should probably be changed to "New Thesaurus" only.

OpenGrok found the string just once, in:

/trunk/main/lingucomponent/source/thesaurus/libnth/nthesimp.cxx (revision
c4c42a0e)

Line:
576  {
577     MutexGuard      aGuard( GetLinguMutex() );
578     return A2OU( "OpenOffice.org New Thesaurus" );
579  }

Since I'm no developer at all I just deleted "OpenOffice.org". 
Hope someone will check if I did it as supposed to.

Should probably also need to be changed in branches AOO41 and AOO42 too

Earlier reported in BugZilla Issue ID: 128483   https://bz.apache.org/ooo/show_bug.cgi?id=1284

![Options_Language settings_Writing aids](https://user-images.githubusercontent.com/5002095/135752386-56dbd928-26d8-4d70-b0b6-20c2c34b7771.png)
83